### PR TITLE
[BUGFIX] Client returns QueryResult even if there is a result

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -37,7 +37,9 @@ final class Client
 
     public function execute(Query $query, array $options = []): QueryResult
     {
-        return new QueryResult($this->configuration, $this->client, $query, $options);
+        $result = new QueryResult($this->configuration, $this->client, $query, $options);
+
+        return $result->valid() ? $result : null;
     }
 
 }


### PR DESCRIPTION
This patch fixes this by returning null when there is no result