### PR TITLE
[TASK] Implement Countable in QueryResult

### DIFF
--- a/src/Search/QueryResult.php
+++ b/src/Search/QueryResult.php
@@ -9,7 +9,7 @@ use SimplyAdmire\Koop\Client;
 use SimplyAdmire\Koop\Configuration;
 use SimplyAdmire\Koop\Model\Publication;
 
-final class QueryResult implements \Iterator
+final class QueryResult implements \Iterator, \Countable
 {
 
     /**
@@ -152,6 +152,11 @@ final class QueryResult implements \Iterator
     public function rewind(): void
     {
         $this->index = 0;
+    }
+
+    public function count(): int
+    {
+        return $this->totalRows;
     }
 
 }


### PR DESCRIPTION
Currently it is not possible to get the amount of rows from the QueryResult. 

This patch implements Countable in the QueryResult to check the amount of rows